### PR TITLE
Allow strings as cookie values.

### DIFF
--- a/angular-cookies.js
+++ b/angular-cookies.js
@@ -183,7 +183,7 @@ angular.module('ngCookies', ['ng']).
          * @param {Object} value Value to be stored.
          */
         put: function(key, value) {
-          $cookies[key] = angular.toJson(value);
+          $cookies[key] = angular.isString(value) ? value : angular.toJson(value);
         },
 
         /**


### PR DESCRIPTION
The problem was that before cookie values could be only as a JSON, but when I only need to have a simple string instead, it did not work.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/bower-angular-cookies/8)

<!-- Reviewable:end -->
