### PR TITLE
Don't need super bleeding edge for angular

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,6 @@
   "main": "./angular-cookies.js",
   "ignore": [],
   "dependencies": {
-    "angular": "1.4.0-rc.0"
+    "angular": ">= 1.0.8"
   }
 }


### PR DESCRIPTION
 Why do you require the absolute tip of angular? I'm getting this conflict with your package now:

```
Unable to find a suitable version for angular, please choose one:
    1) angular#1.3.6 which resolved to 1.3.6 and is required by angular-animate#1.3.6, angular-sanitize#1.3.6, ionic#1.0.0-beta.14
    2) angular#1.3.15 which resolved to 1.3.15 and is required by angular-cookies#1.3.15
    3) angular#>= 1.0.8 which resolved to 1.3.15 and is required by angular-ui-router#0.2.13
    4) angular#>= 1.2.23 which resolved to 1.3.15 and is required by ngCordova#0.1.14-alpha
```

Can you just use whatever version added cookie support?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/bower-angular-cookies/10)

<!-- Reviewable:end -->
